### PR TITLE
[won't merge] Smoke test of merit revamp

### DIFF
--- a/lib/pack_stats/gauge_metric.rb
+++ b/lib/pack_stats/gauge_metric.rb
@@ -10,7 +10,7 @@ module PackStats
 
     sig { params(metric_name: String, count: Integer, tags: T::Array[Tag]).returns(GaugeMetric) }
     def self.for(metric_name, count, tags)
-      name = "modularization.#{metric_name}"
+      name = "test.modularization.#{metric_name}"
       # https://docs.datadoghq.com/metrics/custom_metrics/#naming-custom-metrics
       # Metric names must not exceed 200 characters. Fewer than 100 is preferred from a UI perspective
       if name.length > 200

--- a/lib/pack_stats/private/datadog_reporter.rb
+++ b/lib/pack_stats/private/datadog_reporter.rb
@@ -26,9 +26,9 @@ module PackStats
         packages = ParsePackwerk.all
 
         [
-          *Metrics::Files.get_metrics(source_code_files, app_name),
+          # *Metrics::Files.get_metrics(source_code_files, app_name),
           *Metrics::Packages.get_package_metrics(packages, app_name),
-          *Metrics::PackagesByTeam.get_package_metrics_by_team(packages, app_name),
+          # *Metrics::PackagesByTeam.get_package_metrics_by_team(packages, app_name),
         ]
       end
 


### PR DESCRIPTION
This is a branch off of https://github.com/rubyatscale/pack_stats/pull/35.

This will not be merged – it's only purpose is to allow us to push a set of test metrics to datadog which should make it easier to debug issues with new metrics before they go live.
