### PR TITLE
Metrics emission smoke testing

### DIFF
--- a/lib/pack_stats/gauge_metric.rb
+++ b/lib/pack_stats/gauge_metric.rb
@@ -10,7 +10,8 @@ module PackStats
 
     sig { params(metric_name: String, count: Integer, tags: T::Array[Tag]).returns(GaugeMetric) }
     def self.for(metric_name, count, tags)
-      name = "modularization.#{metric_name}"
+      # This can be incremented with new tests
+      name = "test.0.modularization.#{metric_name}"
       # https://docs.datadoghq.com/metrics/custom_metrics/#naming-custom-metrics
       # Metric names must not exceed 200 characters. Fewer than 100 is preferred from a UI perspective
       if name.length > 200


### PR DESCRIPTION
- Emit metrics under `test.0` prefix. The numeric portion can be incremented across new tests (optionally).
- Make networking more resilient
