### PR TITLE
use shared config for CD, stale, triage; remove unsupported Ruby versions from CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,22 +5,8 @@ on:
     workflows: [CI]
     types: [completed]
     branches: [main]
+
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Tag and Push Gem
-        id: tag-and-push-gem
-        uses: discourse/publish-rubygems-action@v2
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          GIT_EMAIL: ${{secrets.GUSTO_GIT_EMAIL}}
-          GIT_NAME: ${{secrets.GUSTO_GIT_NAME}}
-          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
-      - name: Create GitHub Release
-        run: gh release create v${{steps.tag-and-push-gem.outputs.gem_version}} --generate-notes
-        if: ${{ steps.tag-and-push-gem.outputs.new_version == 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  call-workflow-from-shared-config:
+    uses: rubyatscale/shared-config/.github/workflows/cd.yml@main
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   rspec:
@@ -8,14 +12,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.7
-          # See comment comes from https://github.com/ruby/setup-ruby#matrix-of-ruby-versions
-          # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-          - '3.0'
           - 3.1
           - 3.2
           - 3.3
-          - head
     env:
       BUNDLE_GEMFILE: Gemfile
     name: "RSpec tests: Ruby ${{ matrix.ruby }}"
@@ -37,6 +36,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: head
+          ruby-version: 3.3
       - name: Run static type checks
         run: bundle exec srb tc

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,8 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  call-workflow-from-shared-config:
+    uses: rubyatscale/shared-config/.github/workflows/stale.yml@main

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,9 @@
+name: Label issues as "triage"
+
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  call-workflow-from-shared-config:
+    uses: rubyatscale/shared-config/.github/workflows/triage.yml@main


### PR DESCRIPTION
This repo doesn't use Rubocop so we can't use the shared CI config. I created an issue to add it: https://github.com/rubyatscale/pack_stats/issues/47