### PR TITLE
Add AGENTS.md and CLAUDE.md for AI coding agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+## What this project is
+
+`pack_stats` collects and reports modularization statistics about a Rails application using packwerk. It sends opinionated metrics (e.g. violation counts, pack sizes, ownership breakdown) to DataDog and other observability systems.
+
+## Commands
+
+```bash
+bundle install
+
+# Run all tests (RSpec)
+bundle exec rspec
+
+# Run a single spec file
+bundle exec rspec spec/path/to/spec.rb
+
+# Type checking (Sorbet)
+bundle exec srb tc
+```
+
+## Architecture
+
+- `lib/pack_stats.rb` — entry point; `PackStats.report_to_datadog!` is the primary public method
+- `lib/pack_stats/` — metric collectors (per-pack and per-team stats), DataDog gauge/distribution reporters, and configuration
+- `spec/` — RSpec tests; `spec/fixtures/` has sample pack structures

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-# AGENTS.md
-
 This file provides guidance to AI coding agents when working with code in this repository.
 
 ## What this project is
@@ -25,4 +23,4 @@ bundle exec srb tc
 
 - `lib/pack_stats.rb` — entry point; `PackStats.report_to_datadog!` is the primary public method
 - `lib/pack_stats/` — metric collectors (per-pack and per-team stats), DataDog gauge/distribution reporters, and configuration
-- `spec/` — RSpec tests; `spec/fixtures/` has sample pack structures
+- `spec/` — RSpec tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` with codebase guidance for AI coding agents (commands, architecture)
- Adds `CLAUDE.md` containing just `@AGENTS.md`, following the [Claude Code best practice](https://code.claude.com/docs/en/claude-code-on-the-web#best-practices) of sharing a single instruction file across agents

This makes the same guidance available to Claude Code (via `CLAUDE.md` import) and other agents like Codex that look for `AGENTS.md`.