### PR TITLE
Explicitly inherit rubocop-rubyfmt's default config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,8 @@ inherit_mode:
 inherit_gem:
   rubocop-gusto:
     - config/default.yml
+  rubocop-rubyfmt:
+    - config/default.yml
 
 plugins:
   - rubocop-gusto


### PR DESCRIPTION
## Summary
- #64 only listed `rubocop-rubyfmt` under `plugins`, relying on it implicitly loading its own `config/default.yml`. This adds an explicit `inherit_gem` entry for `rubocop-rubyfmt`, matching how `rubocop-gusto` is already declared (both `inherit_gem` and `plugins`).

## Test plan
- [x] `bundle exec rubocop` — no offenses (no behavior change; config was already being loaded implicitly)
- [x] `bundle exec srb tc` — no errors
- [x] `bundle exec rspec` — all specs pass