### PR TITLE
Add explicit GITHUB_TOKEN permissions to workflow callers

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,5 +8,7 @@ on:
 
 jobs:
   call-workflow-from-shared-config:
+    permissions:
+      contents: write
     uses: rubyatscale/shared-config/.github/workflows/cd.yml@main
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,4 +5,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   call-workflow-from-shared-config:
+    permissions:
+      issues: write
+      pull-requests: write
     uses: rubyatscale/shared-config/.github/workflows/stale.yml@main

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,4 +6,6 @@ on:
       - opened
 jobs:
   call-workflow-from-shared-config:
+    permissions:
+      issues: write
     uses: rubyatscale/shared-config/.github/workflows/triage.yml@main


### PR DESCRIPTION
Resolves the three open `actions/missing-workflow-permissions` CodeQL
alerts (#1, #3, #4). Each is a single-job caller of a reusable workflow in
rubyatscale/shared-config, so the permissions block goes job-level, right
above `uses:`, matching the query_packwerk precedent. A caller's block is
the ceiling for the called workflow, so each grant covers exactly what the
callee does and nothing more.

- cd.yml -> contents: write. shared-config's cd.yml checks out with
  persisted credentials and runs discourse/publish-rubygems-action, which
  does `rake release` (a raw git push of the version tag), then
  `gh release create`. Anything less breaks the gem release.
- stale.yml -> issues: write + pull-requests: write. shared-config's
  stale.yml runs actions/stale, which comments on and closes both stale
  issues and stale PRs. The implicit read of repo contents still works
  without naming contents.
- triage.yml -> issues: write. shared-config's triage.yml only runs
  `gh issue edit --add-label triage`.

ci.yml already declares workflow-level `contents: read` and codeql.yml
already declares its own block, so both are left untouched.


### Alerts resolved

- [#4](https://github.com/rubyatscale/pack_stats/security/code-scanning/4) `actions/missing-workflow-permissions` (medium) — `.github/workflows/cd.yml:11`
- [#3](https://github.com/rubyatscale/pack_stats/security/code-scanning/3) `actions/missing-workflow-permissions` (medium) — `.github/workflows/stale.yml:8`
- [#1](https://github.com/rubyatscale/pack_stats/security/code-scanning/1) `actions/missing-workflow-permissions` (medium) — `.github/workflows/triage.yml:9`

### Verification

- Every job in every flagged workflow now has an effective `permissions:` block (cross-checked by parsing the YAML against the alert list).
- `actionlint` output is byte-identical to `main` — no new findings introduced.
- `codeql.yml` untouched.
